### PR TITLE
fix: improve CLS and hero image presentation

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -159,7 +159,7 @@ const footerLinks = {
     <!-- Bottom bar -->
     <div class="mt-12 border-t border-secondary-foreground/10 pt-8">
       <div class="flex flex-col items-center gap-4">
-        <img src={logoDark.src} alt="Valiant Vineyards" class="h-16 opacity-70" />
+        <img src={logoDark.src} alt="Valiant Vineyards" width="135" height="64" class="h-16 opacity-70" />
         <div class="flex flex-col items-center gap-1 text-sm text-secondary-foreground/70">
           <a
             href={address.googleMapsUrl}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -34,7 +34,7 @@ const featuredPosts = sortedPosts.slice(0, 3);
         quality={80}
       />
       <!-- Light dark overlay -->
-      <div class="absolute inset-0 bg-black/25"></div>
+      <div class="absolute inset-0 bg-black/40"></div>
 
       <!-- Content card -->
       <div class="container relative mx-auto px-4 lg:px-8">


### PR DESCRIPTION
Add explicit width/height to footer logo to reduce layout shifts. Darken homepage hero overlay to compensate for optimized image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)