### PR TITLE
Add cache headers for font files

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -7,3 +7,7 @@
 # Cache hashed assets for 1 year (they have unique filenames)
 /_astro/*
   Cache-Control: public, max-age=31536000, immutable
+
+# Cache fonts for 1 year
+/fonts/*
+  Cache-Control: public, max-age=31536000, immutable


### PR DESCRIPTION
Fonts are now cached for 1 year with immutable flag, matching the existing _astro asset caching strategy.