### PR TITLE
Improve text contrast on neutral-50 backgrounds for accessibility

### DIFF
--- a/src/pages/bed-and-breakfast.astro
+++ b/src/pages/bed-and-breakfast.astro
@@ -406,7 +406,7 @@ const amenities = [
       <h2 class="font-serif text-3xl font-semibold tracking-tight sm:text-4xl mb-4">
         Ready to Book Your Stay?
       </h2>
-      <p class="text-muted-foreground mb-8 max-w-xl mx-auto">
+      <p class="text-foreground mb-8 max-w-xl mx-auto">
         Call us to reserve your room and start planning your getaway.
       </p>
       <Button

--- a/src/pages/private-events.astro
+++ b/src/pages/private-events.astro
@@ -380,7 +380,7 @@ const eventTypes = [
       <h2 class="font-serif text-3xl font-semibold tracking-tight sm:text-4xl mb-4">
         Ready to Plan Your Event?
       </h2>
-      <p class="text-muted-foreground mb-8 max-w-xl mx-auto">
+      <p class="text-foreground mb-8 max-w-xl mx-auto">
         Contact us to discuss your vision and check availability. Our team is here to help make your event unforgettable.
       </p>
       <div class="flex flex-col sm:flex-row gap-4 justify-center">

--- a/src/pages/tasting-room.astro
+++ b/src/pages/tasting-room.astro
@@ -182,7 +182,7 @@ import { hours, contact } from "../data/site-info";
 
             <div class="mt-8 p-6 bg-neutral-50">
               <h3 class="font-semibold mb-2">Reservations</h3>
-              <p class="text-muted-foreground mb-4">
+              <p class="text-foreground mb-4">
                 Walk-ins are welcome during regular hours. For appointments outside normal hours or to arrange a private tasting, please contact us.
               </p>
               <div class="flex flex-col sm:flex-row gap-3">

--- a/src/pages/weddings.astro
+++ b/src/pages/weddings.astro
@@ -130,7 +130,7 @@ const includedServices = [
         <h2 class="font-serif text-3xl font-semibold tracking-tight sm:text-4xl mb-4">
           A Venue Like No Other
         </h2>
-        <p class="text-lg text-muted-foreground max-w-2xl mx-auto">
+        <p class="text-lg text-foreground max-w-2xl mx-auto">
           Every corner of our vineyard tells a story, and we can't wait to help write yours.
         </p>
       </div>
@@ -364,7 +364,7 @@ const includedServices = [
   <!-- Back to Private Events -->
   <section class="bg-neutral-50 py-12">
     <div class="container mx-auto px-4 lg:px-8 text-center">
-      <p class="text-muted-foreground mb-4">Planning a different type of event?</p>
+      <p class="text-foreground mb-4">Planning a different type of event?</p>
       <Button
         href="/private-events/"
         variant="gold-outline"


### PR DESCRIPTION
Change text-muted-foreground to text-foreground in sections with bg-neutral-50 backgrounds to ensure WCAG AA compliance (~15:1 contrast ratio instead of borderline 5.6:1).