### PR TITLE
Add Google Maps to CSP frame-src directive

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -5,7 +5,7 @@
   Referrer-Policy: strict-origin-when-cross-origin
   Strict-Transport-Security: max-age=31536000; includeSubDomains
   Permissions-Policy: geolocation=(), microphone=(), camera=()
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' cdn-cookieyes.com www.googletagmanager.com challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https:; frame-src challenges.cloudflare.com; font-src 'self'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' cdn-cookieyes.com www.googletagmanager.com challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https:; frame-src challenges.cloudflare.com www.google.com; font-src 'self'
 
 # Cache hashed assets for 1 year (they have unique filenames)
 /_astro/*


### PR DESCRIPTION
Allow www.google.com in frame-src to fix blocked Google Maps embed on the contact page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)