### PR TITLE
Add Mailchimp domain to CSP script-src for newsletter forms

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -5,7 +5,7 @@
   Referrer-Policy: strict-origin-when-cross-origin
   Strict-Transport-Security: max-age=31536000; includeSubDomains
   Permissions-Policy: geolocation=(), microphone=(), camera=()
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' cdn-cookieyes.com www.googletagmanager.com challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https:; frame-src challenges.cloudflare.com www.google.com; font-src 'self'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' cdn-cookieyes.com www.googletagmanager.com challenges.cloudflare.com *.list-manage.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https:; frame-src challenges.cloudflare.com www.google.com; font-src 'self'
 
 # Cache hashed assets for 1 year (they have unique filenames)
 /_astro/*


### PR DESCRIPTION
The JSONP-based newsletter subscription was being blocked by CSP because *.list-manage.com wasn't in the script-src directive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)