### PR TITLE
Fix license timeline border clipping on mobile

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -122,7 +122,7 @@ import eldonImage from "../assets/images/eldon-green-background.jpg";
           </div>
 
           <!-- First License -->
-          <div class="border-l-4 border-gold bg-secondary/5 -ml-6 pl-12 py-6">
+          <div class="border-l-4 border-gold bg-secondary/5 lg:-ml-6 pl-6 lg:pl-12 py-6">
             <span class="text-sm font-semibold uppercase tracking-wider text-gold">July 1996</span>
             <h3 class="mt-2 font-serif text-2xl font-semibold">License BW-SD-1</h3>
             <p class="mt-4 text-lg text-muted-foreground">


### PR DESCRIPTION
Make the negative margin offset responsive so it only applies on lg+ screens where container padding is sufficient to accommodate it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)