### PR TITLE
Add default consent state for Google Consent Mode

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -70,10 +70,17 @@ const ogImageURL = new URL(image, Astro.site);
     <script is:inline async id="cookieyes" type="text/javascript" src="https://cdn-cookieyes.com/client_data/6ba0fbf3ca0655582cd3cb4e/script.js"></script>
 
     <!-- Google Analytics - consent managed by CookieYes GCM -->
-    <script is:inline async src="https://www.googletagmanager.com/gtag/js?id=G-PVVXRK70TC"></script>
     <script is:inline>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
+      gtag('consent', 'default', {
+        'analytics_storage': 'denied',
+        'ad_storage': 'denied',
+        'wait_for_update': 500
+      });
+    </script>
+    <script is:inline async src="https://www.googletagmanager.com/gtag/js?id=G-PVVXRK70TC"></script>
+    <script is:inline>
       gtag('js', new Date());
       gtag('config', 'G-PVVXRK70TC');
     </script>

--- a/src/pages/tasting-room-sign-up.astro
+++ b/src/pages/tasting-room-sign-up.astro
@@ -21,10 +21,17 @@ import logo from "../assets/logos/logo-dark.svg";
     <script is:inline id="cookieyes" type="text/javascript" src="https://cdn-cookieyes.com/client_data/6ba0fbf3ca0655582cd3cb4e/script.js"></script>
 
     <!-- Google Analytics - consent managed by CookieYes GCM -->
-    <script is:inline async src="https://www.googletagmanager.com/gtag/js?id=G-PVVXRK70TC"></script>
     <script is:inline>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
+      gtag('consent', 'default', {
+        'analytics_storage': 'denied',
+        'ad_storage': 'denied',
+        'wait_for_update': 500
+      });
+    </script>
+    <script is:inline async src="https://www.googletagmanager.com/gtag/js?id=G-PVVXRK70TC"></script>
+    <script is:inline>
       gtag('js', new Date());
       gtag('config', 'G-PVVXRK70TC');
     </script>


### PR DESCRIPTION
Set analytics_storage and ad_storage to 'denied' by default before GA4 loads. CookieYes will update consent state after user acceptance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)