### PR TITLE
Add all GCM consent type defaults

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -74,8 +74,13 @@ const ogImageURL = new URL(image, Astro.site);
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('consent', 'default', {
-        'analytics_storage': 'denied',
         'ad_storage': 'denied',
+        'ad_user_data': 'denied',
+        'ad_personalization': 'denied',
+        'analytics_storage': 'denied',
+        'functionality_storage': 'denied',
+        'personalization_storage': 'denied',
+        'security_storage': 'granted',
         'wait_for_update': 500
       });
     </script>

--- a/src/pages/tasting-room-sign-up.astro
+++ b/src/pages/tasting-room-sign-up.astro
@@ -25,8 +25,13 @@ import logo from "../assets/logos/logo-dark.svg";
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('consent', 'default', {
-        'analytics_storage': 'denied',
         'ad_storage': 'denied',
+        'ad_user_data': 'denied',
+        'ad_personalization': 'denied',
+        'analytics_storage': 'denied',
+        'functionality_storage': 'denied',
+        'personalization_storage': 'denied',
+        'security_storage': 'granted',
         'wait_for_update': 500
       });
     </script>


### PR DESCRIPTION
Include all 7 consent types required by Google Consent Mode: ad_storage, ad_user_data, ad_personalization, analytics_storage, functionality_storage, personalization_storage, security_storage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)