### PR TITLE
Add health check endpoint and update robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,6 @@
 User-agent: *
 Allow: /
+Disallow: /health/
+Disallow: /tasting-room-sign-up/
 
 Sitemap: https://valiantvineyards.us/sitemap-index.xml

--- a/src/pages/health.astro
+++ b/src/pages/health.astro
@@ -1,0 +1,5 @@
+---
+Astro.response.headers.set("Content-Type", "text/plain");
+Astro.response.headers.set("X-Robots-Tag", "noindex, nofollow");
+---
+ok


### PR DESCRIPTION
Add /health page for UptimeRobot monitoring with noindex headers. Block /health and /tasting-room-sign-up from crawlers in robots.txt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)